### PR TITLE
Add LOCALSTACK_HOST environment override

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ awslocal kinesis list-streams
 
 You can use the following environment variables for configuration:
 
+* `LOCALSTACK_HOST`: Set the hostname for the localstack instance. Useful when you have
+localstack is bound to another interface (i.e. docker-machine).
 * `USE_SSL`: Whether to use `https` endpoint URLs (required if LocalStack has been started
 with `USE_SSL=true` enabled). Defaults to `false`.
 

--- a/bin/awslocal
+++ b/bin/awslocal
@@ -35,11 +35,11 @@ def get_service():
             return param
 
 
-def get_service_endpoint():
+def get_service_endpoint(localstack_host=None):
     service = get_service()
     if service == 's3api':
         service = 's3'
-    return config.get_service_endpoints().get(service)
+    return config.get_service_endpoints(localstack_host=localstack_host).get(service)
 
 
 def usage():
@@ -75,8 +75,10 @@ def main():
     if len(sys.argv) > 1 and sys.argv[1] == '-h':
         return usage()
 
+    localstack_host = os.environ.get('LOCALSTACK_HOST')
+
     # get service and endpoint
-    endpoint = get_service_endpoint()
+    endpoint = get_service_endpoint(localstack_host=localstack_host)
     service = get_service()
     if not endpoint and service:
         print('ERROR: Unable to find LocalStack endpoint for service "%s"' % service)


### PR DESCRIPTION
When you have localstack bound to a different interface (in my case, a docker-machine), you are unable to override the default `localhost` set inside localstack's defaults, which forces you to provide the `--endpoint-url` and defeats the purpose of using `awslocal`.

This PR introduces the environment variable `LOCALSTACK_HOST` that can be set if you have this situation. Here is an example of how it can be used where you have spun up a localstack instance from a docker-compose setup:

```bash
export LOCALSTACK_HOST=$(docker-machine ip)
awslocal kinesis list-streams
```