### PR TITLE
Disable echo in Windows script

### DIFF
--- a/bin/awslocal.bat
+++ b/bin/awslocal.bat
@@ -1,1 +1,3 @@
+@echo off
+
 python %~dp0\awslocal %*


### PR DESCRIPTION
This would fix the issue with echoing the input command on Windows described in the issue https://github.com/localstack/awscli-local/issues/15