### PR TITLE
installation of v2 and patch modification

### DIFF
--- a/bin/awslocal
+++ b/bin/awslocal
@@ -20,6 +20,7 @@ Options:
 import os
 import sys
 import subprocess
+import re
 from threading import Thread
 
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
@@ -69,6 +70,12 @@ def run(cmd, env={}):
 
     process.wait()
     sys.exit(process.returncode)
+
+
+def awscli_is_v1(version):
+    if re.match(r"^1.\d+.\d+$", version):
+        return True
+    return False
 
 
 def main():
@@ -158,12 +165,15 @@ def patch_awscli_libs():
     # TODO: Temporary fix until this PR is merged: https://github.com/aws/aws-cli/pull/3309
 
     import inspect
+    from awscli import __version__ as awscli_version
     from awscli import paramfile
     from awscli.customizations.cloudformation import deploy, package
 
     # add parameter definitions
-    paramfile.PARAMFILE_DISABLED.add('custom.package.s3-endpoint-url')
-    paramfile.PARAMFILE_DISABLED.add('custom.deploy.s3-endpoint-url')
+    if awscli_is_v1(awscli_version):
+        paramfile.PARAMFILE_DISABLED.add('custom.package.s3-endpoint-url')
+        paramfile.PARAMFILE_DISABLED.add('custom.deploy.s3-endpoint-url')
+
     s3_endpoint_arg = {
         'name': 's3-endpoint-url',
         'help_text': (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-awscli
 localstack-client

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,14 @@ if __name__ == '__main__':
         scripts=['bin/awslocal', 'bin/awslocal.bat'],
         package_data={},
         data_files={},
-        install_requires=['awscli', 'localstack-client'],
+        install_requires=['localstack-client'],
+        extras_require={
+            'v1': 'awscli',
+            'v2': [
+                'botocore @ git+https://github.com/boto/botocore.git@v2#egg=botocore',
+                'awscli @ git+https://github.com/aws/aws-cli.git@v2#egg=awscli'
+            ]
+        },
         license="Apache License 2.0",
         classifiers=[
             "Programming Language :: Python :: 2",


### PR DESCRIPTION
As suggested in issue #20 awscli was removed from requiremnts.txt

setup.py manages the installation of awscli for each version.
Now the installation works like this:
```
# base package without dependencies
pip install awscli-local
# package with v1 AWS CLI
pip install awscli-local[v1]
# package with v2 AWS CLI
pip install awscli-local[v2]
```

An the code now verifies the awscli to modify the patch.
