### PR TITLE
Added Warning message for virtual addressing style in aws/config

### DIFF
--- a/bin/awslocal
+++ b/bin/awslocal
@@ -153,6 +153,20 @@ def run_in_process():
     Modifies the command line args in sys.argv and calls the AWS cli
     method directly in this process.
     """
+    profile_name = (
+        sys.argv[sys.argv.index('--profile') + 1] if '--profile' in sys.argv else 'default')
+
+    import botocore.session
+
+    session = botocore.session.get_session()
+    profiles = session.full_config['profiles']
+    if profiles:
+        current_profile = profiles[profile_name]
+        if 's3' in current_profile and 'addressing_style' in current_profile['s3']:
+            msg = 'Addressing style is being set to \'virtual\' in the aws config.' + \
+                ' Please change it to the \'path\'.'
+            print('WARNING: %s' % msg)
+
     import awscli.clidriver
     if os.environ.get('LC_CTYPE', '') == 'UTF-8':
         os.environ['LC_CTYPE'] = 'en_US.UTF-8'

--- a/bin/awslocal
+++ b/bin/awslocal
@@ -24,6 +24,7 @@ import re
 from threading import Thread
 
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
+S3_VIRTUAL_ENDPOINT_HOSTNAME = 's3.localhost.localstack.cloud'
 if os.path.isdir(os.path.join(PARENT_FOLDER, '.venv')):
     sys.path.insert(0, PARENT_FOLDER)
 
@@ -156,20 +157,28 @@ def run_in_process():
     profile_name = (
         sys.argv[sys.argv.index('--profile') + 1] if '--profile' in sys.argv else 'default')
 
+    endpoint_url = (
+        sys.argv[sys.argv.index('--endpoint-url') + 1] if '--endpoint-url' in sys.argv else '')
+
+    if not endpoint_url:
+        endpoint_url = (
+            sys.argv[sys.argv.index('--endpoint') + 1] if '--endpoint' in sys.argv else '')
+
     import botocore.session
 
     session = botocore.session.get_session()
 
-    try:
-        profiles = session.full_config.get('profiles')
-        if profiles:
-            current_profile = profiles.get(profile_name)
-            if (current_profile['s3'].get('addressing_style') in ['virtual', 'auto']):
-                msg = 'Addressing style is being set to \'virtual\' or \'auto\' in the aws config.' + \
-                    ' Please change it to the \'path\'.'
-                print('WARNING: %s' % msg)
-    except KeyError:
-        pass
+    if S3_VIRTUAL_ENDPOINT_HOSTNAME not in endpoint_url:
+        try:
+            profiles = session.full_config.get('profiles')
+            if profiles:
+                current_profile = profiles.get(profile_name)
+                if (current_profile['s3'].get('addressing_style') in ['virtual', 'auto']):
+                    msg = 'Addressing style is being set to \'virtual\' or \'auto\' in the aws config.' + \
+                        ' Please change it to the \'path\'.'
+                    print('WARNING: %s' % msg)
+        except KeyError:
+            pass
 
     import awscli.clidriver
     if os.environ.get('LC_CTYPE', '') == 'UTF-8':

--- a/bin/awslocal
+++ b/bin/awslocal
@@ -161,9 +161,9 @@ def run_in_process():
     session = botocore.session.get_session()
 
     try:
-        profiles = session.full_config['profiles']
+        profiles = session.full_config.get('profiles')
         if profiles:
-            current_profile = profiles[profile_name]
+            current_profile = profiles.get(profile_name)
             if (current_profile['s3'].get('addressing_style') in ['virtual', 'auto']):
                 msg = 'Addressing style is being set to \'virtual\' or \'auto\' in the aws config.' + \
                     ' Please change it to the \'path\'.'

--- a/bin/awslocal
+++ b/bin/awslocal
@@ -159,13 +159,17 @@ def run_in_process():
     import botocore.session
 
     session = botocore.session.get_session()
-    profiles = session.full_config['profiles']
-    if profiles:
-        current_profile = profiles[profile_name]
-        if 's3' in current_profile and 'addressing_style' in current_profile['s3']:
-            msg = 'Addressing style is being set to \'virtual\' in the aws config.' + \
-                ' Please change it to the \'path\'.'
-            print('WARNING: %s' % msg)
+
+    try:
+        profiles = session.full_config['profiles']
+        if profiles:
+            current_profile = profiles[profile_name]
+            if (current_profile['s3'].get('addressing_style') in ['virtual', 'auto']):
+                msg = 'Addressing style is being set to \'virtual\' or \'auto\' in the aws config.' + \
+                    ' Please change it to the \'path\'.'
+                print('WARNING: %s' % msg)
+    except KeyError:
+        pass
 
     import awscli.clidriver
     if os.environ.get('LC_CTYPE', '') == 'UTF-8':


### PR DESCRIPTION
### Fix/Added in this PR
- If s3 addressing style is being set to 'virtual' in ~/.aws/config for the respective profile, then print WARNING message.