### PR TITLE
Remove obsolete/erroneous FORCE_V2 flag

### DIFF
--- a/bin/awslocal
+++ b/bin/awslocal
@@ -23,8 +23,6 @@ import subprocess
 import re
 from threading import Thread
 
-FORCE_V2 = True
-
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
 S3_VIRTUAL_ENDPOINT_HOSTNAME = 's3.localhost.localstack.cloud'
 if os.path.isdir(os.path.join(PARENT_FOLDER, '.venv')):
@@ -72,8 +70,6 @@ def run(cmd, env={}):
 
 
 def awscli_is_v1():
-    if FORCE_V2:
-        return False
     try:
         from awscli import __version__ as awscli_version
         if re.match(r'^1.\d+.\d+$', awscli_version):
@@ -89,8 +85,6 @@ def main():
     if len(sys.argv) > 1 and sys.argv[1] == '-h':
         return usage()
     try:
-        if FORCE_V2:
-            raise
         import awscli.clidriver  # noqa: F401
     except Exception:
         return run_as_separate_process()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ if __name__ == '__main__':
 
     setup(
         name='awscli-local',
-        version='0.16',
+        version='0.17',
         description='Thin wrapper around the "aws" command line interface for use with LocalStack',
         author='Waldemar Hummer',
         author_email='waldemar.hummer@gmail.com',


### PR DESCRIPTION
Remove obsolete/erroneous `FORCE_V2` flag (was used for debugging, should have never made it into the production release, actually).