### PR TITLE
Removed erroneous } in the alternative command

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ pip install https://github.com/boto/botocore/archive/v2.zip https://github.com/a
 
 This package can be replaced by a single bash alias, except for `cloudformation package ...` as this command requires an additional `--s3-endpoint-url` parameter:
 ```console
-alias awslocal="AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=${DEFAULT_REGION:-$AWS_DEFAULT_REGION}} aws --endpoint-url=http://${LOCALSTACK_HOST:-localhost}:4566"
+alias awslocal="AWS_ACCESS_KEY_ID=test AWS_SECRET_ACCESS_KEY=test AWS_DEFAULT_REGION=${DEFAULT_REGION:-$AWS_DEFAULT_REGION} aws --endpoint-url=http://${LOCALSTACK_HOST:-localhost}:4566"
 ```
 
 ## License


### PR DESCRIPTION
I found that the command didn't work as intended in bash, tweaked to what I found the escaping that was needed