### PR TITLE
CHORE: Add long description to the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,17 @@
 
 from setuptools import setup
 
+with open('README.md', encoding='utf8') as f:
+    README = f.read()
+
 if __name__ == '__main__':
 
     setup(
         name='awscli-local',
         version='0.18',
         description='Thin wrapper around the "aws" command line interface for use with LocalStack',
+        long_description=README,
+        long_description_content_type='text/markdown',
         author='Waldemar Hummer',
         author_email='waldemar.hummer@gmail.com',
         url='https://github.com/localstack/awscli-local',


### PR DESCRIPTION
## Description

Currently, the PyPi page of AWS CLI Local shows: 
![image](https://user-images.githubusercontent.com/47351025/155974005-f47e7a8d-f440-4b4a-9a96-2fed570d4150.png)

This PR fixes that by providing a (long) project description.