### PR TITLE
Pass HOME env variable for use with asdf

### DIFF
--- a/bin/awslocal
+++ b/bin/awslocal
@@ -29,7 +29,7 @@ if os.path.isdir(os.path.join(PARENT_FOLDER, '.venv')):
     sys.path.insert(0, PARENT_FOLDER)
 
 # names of additional environment variables to pass to subprocess
-ENV_VARS_TO_PASS = ['PATH', 'PYTHONPATH', 'SYSTEMROOT']
+ENV_VARS_TO_PASS = ['PATH', 'PYTHONPATH', 'SYSTEMROOT', 'HOME']
 
 from localstack_client import config  # noqa: E402
 


### PR DESCRIPTION
Following #59, pass HOME env variable to ENV_VARS_TO_PASS.