### PR TITLE
Remove silent fallbacks for env config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pip install https://github.com/boto/botocore/archive/v2.zip https://github.com/a
 
 ## Change Log
 
-* v0.21: Remove fallbacks for credentials and region in the environment
+* v0.21: Use placeholder credentials and region only if Boto cannot not find them
 * v0.20: Small fixes for Python 2.x backward compatibility
 * v0.19: Patch botocore to skip adding `data-` host prefixes to endpoint URLs
 * v0.18: Pass `SYSTEMROOT` env variable to fix "_Py_HashRandomization_Init" error on Windows

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ You can use the following environment variables for configuration:
   Useful when you have LocalStack bound to a different host (e.g., within docker-compose).
 * `LOCALSTACK_HOST` (deprecated): A <hostname>:<port> variable defining where to find LocalStack (default: localhost:4566).
 * `USE_SSL` (deprecated): Whether to use SSL when connecting to LocalStack (default: False).
-* `DEFAULT_REGION`: Set the default region. Overrides `AWS_DEFAULT_REGION` environment variable.
 
 ## Completion
 
@@ -93,6 +92,7 @@ pip install https://github.com/boto/botocore/archive/v2.zip https://github.com/a
 
 ## Change Log
 
+* v0.21: Remove fallbacks for credentials and region in the environment
 * v0.20: Small fixes for Python 2.x backward compatibility
 * v0.19: Patch botocore to skip adding `data-` host prefixes to endpoint URLs
 * v0.18: Pass `SYSTEMROOT` env variable to fix "_Py_HashRandomization_Init" error on Windows

--- a/bin/awslocal
+++ b/bin/awslocal
@@ -23,6 +23,8 @@ import subprocess
 import re
 from threading import Thread
 
+from boto3.session import Session
+
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
 S3_VIRTUAL_ENDPOINT_HOSTNAME = 's3.localhost.localstack.cloud'
 if os.path.isdir(os.path.join(PARENT_FOLDER, '.venv')):
@@ -103,6 +105,16 @@ def prepare_environment():
         'PYTHONWARNINGS', 'ignore:Unverified HTTPS request')
 
     env_dict.pop('AWS_DATA_PATH', None)
+
+    session = Session()
+    credentials = session.get_credentials()
+
+    if not credentials:
+        env_dict['AWS_ACCESS_KEY_ID'] = 'test'
+        env_dict['AWS_SECRET_ACCESS_KEY'] = 'test'
+
+    if not session.region_name:
+        env_dict['AWS_DEFAULT_REGION'] = 'us-east-1'
 
     # update environment variables in the current process
     os.environ.update(env_dict)

--- a/bin/awslocal
+++ b/bin/awslocal
@@ -101,19 +101,6 @@ def prepare_environment():
     env_dict = os.environ.copy()
     env_dict['PYTHONWARNINGS'] = os.environ.get(
         'PYTHONWARNINGS', 'ignore:Unverified HTTPS request')
-    if os.environ.get('DEFAULT_REGION'):
-        if os.environ.get('AWS_DEFAULT_REGION'):
-            msg = 'Environment variable "AWS_DEFAULT_REGION" will be overwritten by "DEFAULT_REGION"'
-            print('INFO: %s' % msg)
-        env_dict['AWS_DEFAULT_REGION'] = os.environ.get(
-            'DEFAULT_REGION')
-    else:
-        env_dict['AWS_DEFAULT_REGION'] = os.environ.get(
-            'AWS_DEFAULT_REGION', 'us-east-1')
-    env_dict['AWS_ACCESS_KEY_ID'] = os.environ.get(
-        'AWS_ACCESS_KEY_ID', 'test')
-    env_dict['AWS_SECRET_ACCESS_KEY'] = os.environ.get(
-        'AWS_SECRET_ACCESS_KEY', 'test')
 
     env_dict.pop('AWS_DATA_PATH', None)
 


### PR DESCRIPTION
This PR removes the forced fallbacks for AWS credentials in the environment.

AWS CLI/boto3 has a well-defined priority for reading these config options from env, config file, etc. Prior to this PR, this was highjacked and `awscli` would often cause access denied/resource not found errors.

This PR will also enable the use of profiles and `~/.aws/config` which was not possible earlier.

For LocalStack core, we have full documentation on credentials, and furthermore safeguards to prevent accidental use of production AWS credentials. See <https://docs.localstack.cloud/references/credentials/>

Fixes https://github.com/localstack/awscli-local/issues/71