### PR TITLE
Replace subprocess call with os.execvpe if run as separate process

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ pip install https://github.com/boto/botocore/archive/v2.zip https://github.com/a
 
 ## Change Log
 
-* v0.21: Use placeholder credentials and region only if Boto cannot not find them
+* v0.21: Use placeholder credentials and region only if Boto cannot not find them, fix output streaming for logs tail call
 * v0.20: Small fixes for Python 2.x backward compatibility
 * v0.19: Patch botocore to skip adding `data-` host prefixes to endpoint URLs
 * v0.18: Pass `SYSTEMROOT` env variable to fix "_Py_HashRandomization_Init" error on Windows

--- a/bin/awslocal
+++ b/bin/awslocal
@@ -31,7 +31,7 @@ if os.path.isdir(os.path.join(PARENT_FOLDER, '.venv')):
     sys.path.insert(0, PARENT_FOLDER)
 
 # names of additional environment variables to pass to subprocess
-ENV_VARS_TO_PASS = ['PATH', 'PYTHONPATH', 'SYSTEMROOT', 'HOME']
+ENV_VARS_TO_PASS = ['PATH', 'PYTHONPATH', 'SYSTEMROOT', 'HOME', 'TERM', 'PAGER']
 
 from localstack_client import config  # noqa: E402
 

--- a/bin/awslocal
+++ b/bin/awslocal
@@ -54,24 +54,13 @@ def usage():
     print(__doc__.strip())
 
 
-def run(cmd, env={}):
-
-    def output_reader(pipe, out):
-        out_binary = os.fdopen(out.fileno(), 'wb')
-        with pipe:
-            for line in iter(pipe.readline, b''):
-                out_binary.write(line)
-                out_binary.flush()
-
-    process = subprocess.Popen(
-        cmd, env=env,
-        stderr=subprocess.PIPE, stdout=subprocess.PIPE, stdin=subprocess.PIPE)
-
-    Thread(target=output_reader, args=[process.stdout, sys.stdout]).start()
-    Thread(target=output_reader, args=[process.stderr, sys.stderr]).start()
-
-    process.wait()
-    sys.exit(process.returncode)
+def run(cmd, env=None):
+    """
+    Replaces this process with the AWS CLI process, with the given command and environment
+    """
+    if not env:
+        env = {}
+    os.execvpe(cmd[0], cmd, env)
 
 
 def awscli_is_v1():


### PR DESCRIPTION
## Motivation
The stream forwarding between the stdout pipe of our subprocess call to run the aws cli in another process is currently broken in certain scenarios.

One example is the log streaming in the aws cli v2, used with `aws logs tail <log_group> --follow`. Using the awslocal wrapper, the output appears only after the process ended - in contrast to a live stream.

## Thoughts about the solution
While we could also just fix our streaming from the subprocess stdout pipe to stdout - it seems more natural to use `os.execvpe` to replace the current process with the aws cli process, and avoid all stream handling.
We do not controll the subprocess in any significant way, and just pipe stdout/stderr and stdin from and to the subprocess, and forward the exit code.

Since we do not need to control the subprocess from our logic, or do anything once it exited, replacing the whole process seemed like a straightforward solution

## Changes
* Replace subprocess call including the stream redirection with a os.execvpe call.