### PR TITLE
Fall back to STS endpoint url as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ pip install https://github.com/boto/botocore/archive/v2.zip https://github.com/a
 
 ## Change Log
 
+* v0.22.0: Use fallback for endpoint detection. Should prevent most cases of `Unable to find LocalStack endpoint for service ...`
 * v0.21.1: Introducing semantic versioning and list of services without endpoints
 * v0.21: Use placeholder credentials and region only if Boto cannot not find them, fix output streaming for logs tail call
 * v0.20: Small fixes for Python 2.x backward compatibility

--- a/bin/awslocal
+++ b/bin/awslocal
@@ -50,7 +50,9 @@ def get_service_endpoint(localstack_host=None):
     if service == 's3api':
         service = 's3'
     endpoints = config.get_service_endpoints(localstack_host=localstack_host)
-    return endpoints.get(service)
+    # defaulting to use the endpoint for STS (could also be one of the other services in the existing list)
+    # otherwise newly-added services in LocalStack would always need to be added to the _service_ports dict in localstack_client
+    return endpoints.get(service) or endpoints.get("sts")
 
 
 def usage():

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
 
     setup(
         name='awscli-local',
-        version='0.21.1',
+        version='0.22.0',
         description=description,
         long_description=README,
         long_description_content_type='text/markdown',


### PR DESCRIPTION

Current situation:
Every new service implementation on our side needs a corresponding entry here: [Source](https://github.com/localstack/localstack-python-client/blob/master/localstack_client/config.py#L14), which I think not many people are aware of and feels unnecessarily restrictive & prone to error on our side.

`awslocal` makes use of `localstack_client` and this list of `_service_ports` to determine the endpoint URL.

Nowadays we don't really use this custom port mapping anymore but the lib still depends on an entry being available in the list. Unfortunately we can't just patch localstack_client for this right now without changing awslocal, so to keep this to a minimum I suggest the following change where we simply default to use the endpoint URL of a fairly standard service `sts`.

This is just a way to get to the normal default endpoint URL by re-using the endpoint-building logic in `localstack_client`.
