### PR TITLE
Add basic github action for regression testing

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -58,7 +58,8 @@ jobs:
           localstack start -d
           localstack wait -t 30
 
-      - name: Verify successful deployment
+      - name: Test usage of awslocal
         run: |
           awslocal lambda list-functions
-          awslocal ssm list-parameters
+          awslocal s3api list-buckets
+          awslocal s3 ls

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -28,6 +28,7 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ matrix.access-key-id }}
       AWS_REGION: ${{ matrix.region }}
       AWS_DEFAULT_REGION: ${{ matrix.region }}
+      AWS_SECRET_ACCESS_KEY: test
 
     steps:
       - uses: actions/checkout@v4
@@ -38,10 +39,14 @@ jobs:
           python-version: '${{ matrix.python-version }}'
 
       - name: Install deps
-        run: pip install .
+        run: pip install '.[ver1]'
 
-      - name: Install localstack CLI
-        run: pip install localstack
+      - name: Check aws-cli version
+        run: |
+          aws --version
+          awslocal --version
+          which aws
+          which awslocal
 
       - name: Start and wait for localstack (Community)
         timeout-minutes: 10
@@ -49,13 +54,6 @@ jobs:
           docker pull localstack/localstack:latest
           localstack start -d
           localstack wait -t 30
-      
-      - name: Check aws-cli version
-        run: |
-          aws --version
-          awslocal --version
-          which aws
-          which awslocal
 
       - name: Verify successful deployment
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,63 @@
+name: Integration test
+
+on:
+  push:
+    paths-ignore:
+      - 'README.md'
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - { python-version: '3.12', region: us-west-1, access-key-id: '000000000001'}
+          - { python-version: '3.12', region: us-east-1, access-key-id: 'test'}
+          - { python-version: '3.11', region: us-east-1, access-key-id: 'test'}
+          - { python-version: '3.10', region: us-east-1, access-key-id: 'test'}
+          - { python-version: '3.9', region: us-east-1, access-key-id: 'test'}
+          - { python-version: '3.8', region: us-east-1, access-key-id: 'test'}
+
+    env:
+      AWS_ACCESS_KEY_ID: ${{ matrix.access-key-id }}
+      AWS_REGION: ${{ matrix.region }}
+      AWS_DEFAULT_REGION: ${{ matrix.region }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: '${{ matrix.python-version }}'
+
+      - name: Install deps
+        run: pip install .
+
+      - name: Install localstack CLI
+        run: pip install localstack
+
+      - name: Start and wait for localstack (Community)
+        timeout-minutes: 10
+        run: |
+          docker pull localstack/localstack:latest
+          localstack start -d
+          localstack wait -t 30
+      
+      - name: Check aws-cli version
+        run: |
+          aws --version
+          awslocal --version
+          which aws
+          which awslocal
+
+      - name: Verify successful deployment
+        run: |
+          awslocal lambda list-functions
+          awslocal ssm list-parameters

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -5,10 +5,10 @@ on:
     paths-ignore:
       - 'README.md'
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
 
 jobs:
   test:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           python-version: '${{ matrix.python-version }}'
 
+      - name: Install localstack CLI
+        run: pip install localstack
+
       - name: Install deps
         run: pip install '.[ver1]'
 


### PR DESCRIPTION
Adds a basic GitHub action regression test  to verify that basic awslocal commands are still working.

Can be extended with multiple other cases as well like:
- More `awslocal ...` service calls
- Different configurations
- awscli v1 vs. v2
- ...