### PR TITLE
:whale: :tada: initial version of the cli dockerized

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.13.2-alpine3.21 AS builder
+
+WORKDIR /usr/src/app
+
+RUN python3 -m venv /venv
+ENV PATH="/venv/bin:$PATH"
+
+RUN pip install --upgrade pip
+#RUN apk add cargo
+
+COPY requirements.txt requirements.txt
+
+RUN pip install --no-cache-dir -r requirements.txt 
+
+FROM python:3.13.2-alpine3.21 AS service
+WORKDIR /root/app/site-packages
+COPY --from=builder /venv /venv
+ENV PATH=/venv/bin:$PATH
+
+COPY . .
+
+USER root
+
+VOLUME /app/data
+
+ENTRYPOINT ["/root/app/site-packages/bin/awslocal"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM python:3.13.2-alpine3.21 AS builder
+ARG BUILDER_IMAGE
+ARG AWS_CLI_VERSION
+FROM ${BUILDER_IMAGE} AS builder
 
 WORKDIR /usr/src/app
 
@@ -12,7 +14,11 @@ COPY requirements.txt requirements.txt
 
 RUN pip install --no-cache-dir -r requirements.txt 
 
-FROM python:3.13.2-alpine3.21 AS service
+FROM ${BUILDER_IMAGE} AS service
+
+ARG AWS_CLI_VERSION
+RUN apk update && apk add aws-cli==${AWS_CLI_VERSION}
+
 WORKDIR /root/app/site-packages
 COPY --from=builder /venv /venv
 ENV PATH=/venv/bin:$PATH
@@ -23,5 +29,5 @@ USER root
 
 VOLUME /app/data
 
-ENTRYPOINT ["/root/app/site-packages/bin/awslocal"]
+ENTRYPOINT ["python3", "/root/app/site-packages/bin/awslocal"]
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,6 @@
+services:
+
+  awslocal:
+    image: marcellodesales/awslocal
+    build:
+      context: .

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,5 +2,9 @@ services:
 
   awslocal:
     image: marcellodesales/awslocal
+    platform: linux/amd64
     build:
       context: .
+      args:
+        BUILDER_IMAGE: python:3.13.2-alpine3.21
+        AWS_CLI_VERSION: 2.22.10-r0


### PR DESCRIPTION
# 🏗️ Build

```console
$ docker compose build
[+] Building 2.9s (16/16) FINISHED                                                                                                                                   docker-container:kind_khayyam
 => [awslocal internal] load build definition from Dockerfile                                                                                                                                 0.0s
 => => transferring dockerfile: 560B                                                                                                                                                          0.0s
 => [awslocal internal] load metadata for docker.io/library/python:3.13.2-alpine3.21                                                                                                          2.4s
 => [awslocal auth] library/python:pull token for registry-1.docker.io                                                                                                                        0.0s
 => [awslocal internal] load .dockerignore                                                                                                                                                    0.0s
 => => transferring context: 2B                                                                                                                                                               0.0s
 => [awslocal builder 1/6] FROM docker.io/library/python:3.13.2-alpine3.21@sha256:323a717dc4a010fee21e3f1aac738ee10bb485de4e7593ce242b36ee48d6b352                                            0.0s
 => => resolve docker.io/library/python:3.13.2-alpine3.21@sha256:323a717dc4a010fee21e3f1aac738ee10bb485de4e7593ce242b36ee48d6b352                                                             0.0s
 => [awslocal internal] load build context                                                                                                                                                    0.0s
 => => transferring context: 4.83kB                                                                                                                                                           0.0s
 => CACHED [awslocal service 2/4] WORKDIR /root/app/site-packages                                                                                                                             0.0s
 => CACHED [awslocal builder 2/6] WORKDIR /usr/src/app                                                                                                                                        0.0s
 => CACHED [awslocal builder 3/6] RUN python3 -m venv /venv                                                                                                                                   0.0s
 => CACHED [awslocal builder 4/6] RUN pip install --upgrade pip                                                                                                                               0.0s
 => CACHED [awslocal builder 5/6] COPY requirements.txt requirements.txt                                                                                                                      0.0s
 => CACHED [awslocal builder 6/6] RUN pip install --no-cache-dir -r requirements.txt                                                                                                          0.0s
 => CACHED [awslocal service 3/4] COPY --from=builder /venv /venv                                                                                                                             0.0s
 => [awslocal service 4/4] COPY . .                                                                                                                                                           0.0s
 => [awslocal] exporting to docker image format                                                                                                                                               0.4s
 => => exporting layers                                                                                                                                                                       0.0s
 => => exporting manifest sha256:e28f6e86e46b31354deb06e5b58bea31284e54597c500a22fda7968e860440f6                                                                                             0.0s
 => => exporting config sha256:f7d4d2788ef34140c6d1feeae5a6c4958f1b854896da5e511fb5e4ec6ab20f84                                                                                               0.0s
 => => sending tarball                                                                                                                                                                        0.4s
 => [awslocal] importing to docker                                                                                                                                                            0.0s
 => => loading layer aca9de4d1627 32.77kB / 79.77kB                                                                                                                                           0.0s
```

# 🏃 Running

* Entrypoint already executes awslocal

```console
$ docker compose run awslocal

usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help

aws: error: the following arguments are required: command

``