### PR TITLE
Remove stack traces when debug mode is not enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ pip install https://github.com/boto/botocore/archive/v2.zip https://github.com/a
 
 ## Change Log
 
+* v0.23.0: Display full stack traces only in `--debug` mode; non-debug runs now show concise error messages, consistent with `awscli` behavior.
 * v0.22.1: Fix issue with cfn package and cfn deploy with awscli >= 1.41.9
 * v0.22.0: Use fallback for endpoint detection. Should prevent most cases of `Unable to find LocalStack endpoint for service ...`
 * v0.21.1: Introducing semantic versioning and list of services without endpoints

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ pip install https://github.com/boto/botocore/archive/v2.zip https://github.com/a
 
 ## Change Log
 
-* v0.23.0: Display full stack traces only in `--debug` mode; non-debug runs now show concise error messages, consistent with `awscli` behavior.
+* v0.22.2: Display full stack traces only in `--debug` mode; non-debug runs now show concise error messages, consistent with `awscli` behavior.
 * v0.22.1: Fix issue with cfn package and cfn deploy with awscli >= 1.41.9
 * v0.22.0: Use fallback for endpoint detection. Should prevent most cases of `Unable to find LocalStack endpoint for service ...`
 * v0.21.1: Introducing semantic versioning and list of services without endpoints

--- a/bin/awslocal
+++ b/bin/awslocal
@@ -21,6 +21,7 @@ import os
 import sys
 import subprocess
 import re
+import traceback
 
 PARENT_FOLDER = os.path.realpath(os.path.join(os.path.dirname(__file__), '..'))
 S3_VIRTUAL_ENDPOINT_HOSTNAME = 's3.localhost.localstack.cloud'
@@ -41,6 +42,8 @@ def get_service():
         if not param.startswith('-'):
             return param
 
+def is_debug_mode():
+    return "--debug" in sys.argv
 
 def get_service_endpoint(localstack_host=None):
     service = get_service()
@@ -83,7 +86,14 @@ def main():
     try:
         import awscli.clidriver  # noqa: F401
     except Exception:
-        return run_as_separate_process()
+        try:
+            return run_as_separate_process()
+        except Exception as e:
+            if is_debug_mode():
+                traceback.print_exc()
+            else:
+                print(f"\n{e}")
+            sys.exit(1)
     patch_awscli_libs()
     run_in_process()
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
 
     setup(
         name='awscli-local',
-        version='0.23.0',
+        version='0.22.2',
         description=description,
         long_description=README,
         long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ if __name__ == '__main__':
 
     setup(
         name='awscli-local',
-        version='0.22.1',
+        version='0.23.0',
         description=description,
         long_description=README,
         long_description_content_type='text/markdown',


### PR DESCRIPTION
This PR enhances the usability and devX of the `awslocal` by logging stack traces only when `--debug` is passed  and displaying only error messages by default, matching `awscli` behavior.

**Current Behaviour**

```
sannyasingal@Sannyas-MacBook-Pro ~ % CUSTOMIZE_ACCESS_KEY=1 AWS_ACCESS_KEY_ID=444444444444  awslocal kms create-key 
Traceback (most recent call last):
  File "/Users/sannyasingal/.pyenv/versions/3.11.9/bin/awslocal", line 87, in main
    import awscli.clidriver  # noqa: F401
    ^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'awscli'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/sannyasingal/.pyenv/versions/3.11.9/bin/awslocal", line 268, in <module>
    main()
  File "/Users/sannyasingal/.pyenv/versions/3.11.9/bin/awslocal", line 89, in main
    return run_as_separate_process()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sannyasingal/.pyenv/versions/3.11.9/bin/awslocal", line 151, in run_as_separate_process
    env_dict = prepare_environment()
               ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sannyasingal/.pyenv/versions/3.11.9/bin/awslocal", line 104, in prepare_environment
    credentials = session.get_credentials()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sannyasingal/.pyenv/versions/3.11.9/lib/python3.11/site-packages/boto3/session.py", line 201, in get_credentials
    return self._session.get_credentials()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sannyasingal/.pyenv/versions/3.11.9/lib/python3.11/site-packages/botocore/session.py", line 515, in get_credentials
    ).load_credentials()
      ^^^^^^^^^^^^^^^^^^
  File "/Users/sannyasingal/.pyenv/versions/3.11.9/lib/python3.11/site-packages/botocore/credentials.py", line 2074, in load_credentials
    creds = provider.load()
            ^^^^^^^^^^^^^^^
  File "/Users/sannyasingal/.pyenv/versions/3.11.9/lib/python3.11/site-packages/botocore/credentials.py", line 1149, in load
    credentials = fetcher(require_expiry=False)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/sannyasingal/.pyenv/versions/3.11.9/lib/python3.11/site-packages/botocore/credentials.py", line 1189, in fetch_credentials
    raise PartialCredentialsError(
botocore.exceptions.PartialCredentialsError: Partial credentials found in env, missing: AWS_SECRET_ACCESS_KEY

```


**Expected Behaviour**: 

```
sannyasingal@Sannyas-MacBook-Pro ~ % CUSTOMIZE_ACCESS_KEY=1 AWS_ACCESS_KEY_ID=444444444444  awslocal kms create-key

Partial credentials found in env, missing: AWS_SECRET_ACCESS_KEY

```