### PR TITLE
update CI to use localstack CI auth token

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -61,10 +61,11 @@ jobs:
           cd "$HOME"/bats-core
           sudo ./install.sh /usr/local
 
-      - name: Start and wait for LocalStack (Community)
+      - name: Start and wait for LocalStack
         timeout-minutes: 10
+        env:
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
-          docker pull localstack/localstack:latest
           localstack start -d
           localstack wait -t 30
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -67,7 +67,7 @@ jobs:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
           localstack start -d
-          localstack wait -t 30
+          localstack wait
 
       - name: Run bats tests
         run: |


### PR DESCRIPTION
## Motivation
With the upcoming [image consolidation](https://blog.localstack.cloud/the-road-ahead-for-localstack/), LocalStack will require an auth token to start up.
This PR updates the CI of this project to use the CI token configured as a secret for this project.

Fixes ENG-327.

## Changes
- Set `LOCALSTACK_AUTH_TOKEN` when starting LocalStack.
- Remove unnecessary docker pull and wait timeout